### PR TITLE
Hide inaccurate counts on Dataverse.org home page

### DIFF
--- a/dv_apps/installations/templates/installations/homepage_counts.html
+++ b/dv_apps/installations/templates/installations/homepage_counts.html
@@ -13,10 +13,12 @@
     <!--Metrics-->
     <div class="metrics-wrapper" style="background-color:#fff; width:970px;margin:0;padding:5px;">
         <span class="installs">{{ installation_count|intcomma }} Installations</span>
+        <!--
         <span class="dvs">{{ total_dataverses|intcomma }} Dataverses</span>
         <span class="datasets">{{ total_datasets|intcomma }} Datasets</span>
         {#<span class="files">{{ total_files|intcomma }} Files</span>#}
         <span class="files">{{ total_downloads|intcomma }} Downloads</span>
+        -->
         <!-- <span class="downloads">1,700,000+ Downloads</span> -->
     </div>
 </body>

--- a/dv_apps/installations/templates/installations/map.html
+++ b/dv_apps/installations/templates/installations/map.html
@@ -17,10 +17,12 @@
     <!--Metrics-->
     <div class="metrics-wrapper">
         <span class="installs">{{ installation_count|intcomma }} Installations</span>
+        <!--
         <span class="dvs">{{ total_dataverses|intcomma }} Dataverses</span>
         <span class="datasets">{{ total_datasets|intcomma }} Datasets</span>
         {#<span class="files">{{ total_files|intcomma }} Files</span>#}
         <span class="files">{{ total_downloads|intcomma }} Downloads</span>
+        -->
         <!-- <span class="downloads">1,700,000+ Downloads</span> -->
     </div>
 

--- a/dv_apps/installations/templates/installations/map2.html
+++ b/dv_apps/installations/templates/installations/map2.html
@@ -17,10 +17,12 @@
     <!--Metrics-->
     <div class="metrics-wrapper">
         <span class="installs">{{ installation_count|intcomma }} Installations</span>
+        <!--
         <span class="dvs">{{ total_dataverses|intcomma }} Dataverses</span>
         <span class="datasets">{{ total_datasets|intcomma }} Datasets</span>
         {#<span class="files">{{ total_files|intcomma }} Files</span>#}
         <span class="files">{{ total_downloads|intcomma }} Downloads</span>
+        -->
         <!-- <span class="downloads">1,700,000+ Downloads</span> -->
     </div>
 

--- a/dv_apps/installations/templates/installations/map_orig.html
+++ b/dv_apps/installations/templates/installations/map_orig.html
@@ -17,9 +17,11 @@
     <!--Metrics-->
     <div class="metrics-wrapper">
         <span class="installs">{{ installation_count|intcomma }} Installations</span>
+        <!--
         <span class="dvs">{{ total_dataverses|intcomma }} Dataverses</span>
         <span class="datasets">{{ total_datasets|intcomma }} Datasets</span>
         <span class="files">{{ total_files|intcomma }} Files</span>
+        -->
         <!-- <span class="downloads">1,700,000+ Downloads</span> -->
     </div>
 


### PR DESCRIPTION
Hide inaccurate metrics for Dataverses, Datasets, and Downloads.  Leave
Installations metric as is.

https://github.com/IQSS/miniverse/issues/65